### PR TITLE
update classmethod from_google_play_receipt

### DIFF
--- a/pyinapp/purchase.py
+++ b/pyinapp/purchase.py
@@ -20,7 +20,7 @@ class Purchase(object):
     @classmethod
     def from_google_play_receipt(cls, receipt):
         purchase = {
-            'transaction_id': receipt['orderId'],
+            'transaction_id': receipt.get('orderId', receipt['purchaseToken']),
             'product_id': receipt['productId'],
             'quantity': 1,
             'purchased_at': receipt['purchaseTime']


### PR DESCRIPTION
Google test purchases don't have an orderId field. To track test purchases, you use the purchaseToken field instead