### PR TITLE
Include App Store response in exception & purchase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 
 # PyBuilder
 target/
+*~

--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,4 @@ Purchase is a universal wrapper for Google Play and App Store receipts. It conta
 - **product_id**: what product has been purchased (**product_id** for App Store and **productId** for Google Play);
 - **quantity**: how many products have been purchased (**quantity** for App Store and always **1** for Google Play - there's no such field in Google Play receipt);
 - **purchased_at**: when the product has been purchased, UNIX timestamp (**purchase_date** for App Store and **purchaseTime** for Google Play).
+- **response**: (App Store only) The response(json) from the App Store.

--- a/pyinapp/errors.py
+++ b/pyinapp/errors.py
@@ -1,3 +1,8 @@
 
 class InAppValidationError(Exception):
     """ Base class for all validation errors """
+
+    def __init__(self, msg, response=None):
+        super(InAppValidationError, self).__init__(msg)
+        self.response = response
+

--- a/pyinapp/purchase.py
+++ b/pyinapp/purchase.py
@@ -1,19 +1,21 @@
 
 class Purchase(object):
 
-    def __init__(self, transaction_id, product_id, quantity, purchased_at):
+    def __init__(self, transaction_id, product_id, quantity, purchased_at, response=None):
         self.transaction_id = transaction_id
         self.product_id = product_id
         self.quantity = quantity
         self.purchased_at = purchased_at
+        self.response = response
 
     @classmethod
-    def from_app_store_receipt(cls, receipt):
+    def from_app_store_receipt(cls, receipt, response):
         purchase = {
             'transaction_id': receipt['transaction_id'],
             'product_id': receipt['product_id'],
             'quantity': receipt['quantity'],
-            'purchased_at': receipt['purchase_date']
+            'purchased_at': receipt['purchase_date'],
+            'response': response,
         }
         return cls(**purchase)
 

--- a/tests/test_inapperror.py
+++ b/tests/test_inapperror.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+from pyinapp.appstore import AppStoreValidator
+
+
+def test_include_response_on_status_error():
+    response = {"status": 1}
+    bundle_id = 'com.test.ok'
+
+    with mock.patch('requests.post') as mock_post:
+        mock_json = mock.Mock()
+        mock_json.json.return_value = response
+        mock_post.return_value = mock_json
+
+        try:
+            validator = AppStoreValidator(bundle_id).validate('')
+        except Exception as e:
+            assert e.response == response
+
+
+def test_include_response_on_bundle_id_error():
+    receipt = {"in_app":[], "bundle_id": "com.test.wrong"}
+    response = {"status": 0, "in_app":[], "receipt": receipt}
+    bundle_id = 'com.test.ok'
+
+    with mock.patch('requests.post') as mock_post:
+        mock_json = mock.Mock()
+        mock_json.json.return_value = response
+        mock_post.return_value = mock_json
+
+        try:
+            validator = AppStoreValidator(bundle_id).validate(receipt)
+        except Exception as e:
+            assert e.response == response
+
+
+def test_include_response_on_bid_error():
+    receipt = {"bid": "com.test.wrong"}
+    response = {"status": 0, "in_app":[], "receipt": receipt}
+    bundle_id = 'com.test.ok'
+
+    with mock.patch('requests.post') as mock_post:
+        mock_json = mock.Mock()
+        mock_json.json.return_value = response
+        mock_post.return_value = mock_json
+
+        try:
+            validator = AppStoreValidator(bundle_id).validate(receipt)
+        except Exception as e:
+            assert e.response == response

--- a/tests/test_inapperror.py
+++ b/tests/test_inapperror.py
@@ -1,4 +1,7 @@
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyinapp.appstore import AppStoreValidator
 

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -13,6 +13,7 @@ def test_create_from_google_play_receipt():
     assert purchase.product_id == receipt['productId']
     assert purchase.purchased_at == receipt['purchaseTime']
     assert purchase.quantity == 1
+    assert purchase.response == None
 
 
 def test_create_from_test_google_play_receipt():
@@ -30,15 +31,17 @@ def test_create_from_test_google_play_receipt():
 
 
 def test_create_from_app_store_receipt():
+    response = '["in_app":[]]'
     receipt = {
         'transaction_id': 1337,
         'product_id': 'pew pew',
         'purchase_date': '01.01.2016 12:00',
-        'quantity': 100500
+        'quantity': 100500,
     }
-    purchase = Purchase.from_app_store_receipt(receipt)
+    purchase = Purchase.from_app_store_receipt(receipt, response)
 
     assert purchase.transaction_id == receipt['transaction_id']
     assert purchase.product_id == receipt['product_id']
     assert purchase.purchased_at == receipt['purchase_date']
     assert purchase.quantity == receipt['quantity']
+    assert purchase.response == response

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ envlist = py{27,35}
 commands = py.test -v
 deps =
     pytest
+    mock


### PR DESCRIPTION
Hi Ivan
To be able to keep track of what happens to the purchases I'm including the App Store response in the `InAppValidationError` and in `Purchase`.