### PR TITLE
Appstore "Shared key mismatch" exception handling

### DIFF
--- a/pyinapp/appstore.py
+++ b/pyinapp/appstore.py
@@ -27,8 +27,10 @@ class AppStoreValidator(object):
         else:
             self.url = 'https://buy.itunes.apple.com/verifyReceipt'
 
-    def validate(self, receipt):
+    def validate(self, receipt, password=None):
         receipt_json = {'receipt-data': receipt}
+        if password:
+            receipt_json['password'] = password
 
         try:
             api_response = requests.post(self.url, json=receipt_json).json()


### PR DESCRIPTION
With this small change, now you'll be able to validate your auto-renewing subscription with using your ios app's shared key.

here you can find out how to obtain your app's shared key:
https://stackoverflow.com/questions/5022296/generate-shared-secret-key-in-itunes-connect-for-in-app-purchase#comment26097056_5022296